### PR TITLE
Add C-callable Polya-Gamma RNG API

### DIFF
--- a/inst/include/BayesLogit.h
+++ b/inst/include/BayesLogit.h
@@ -1,0 +1,89 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+// Cross-package C-callable API for BayesLogit Polya-Gamma RNGs.
+
+#ifndef BAYESLOGIT_API_H
+#define BAYESLOGIT_API_H
+
+#include <R_ext/Rdynload.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * These functions use R's RNG but do not call GetRNGstate() or PutRNGstate().
+ * Callers must own R's RNG state before using them, following the same pattern
+ * as native R RNG calls such as unif_rand(), rnorm(), or rgamma().
+ */
+
+typedef double (*BayesLogit_rpg_gamma_t)(double h, double z, int trunc);
+typedef void (*BayesLogit_rpg_gamma_fill_t)(int n, const double *h,
+                                            const double *z, int trunc,
+                                            double *out);
+
+typedef double (*BayesLogit_rpg_devroye_t)(int h, double z);
+typedef void (*BayesLogit_rpg_devroye_fill_t)(int n, const int *h,
+                                              const double *z, double *out);
+
+typedef double (*BayesLogit_rpg_sp_t)(double h, double z, int *iter);
+typedef void (*BayesLogit_rpg_sp_fill_t)(int n, const double *h,
+                                         const double *z, double *out,
+                                         int *iter);
+
+typedef double (*BayesLogit_rpg_hybrid_t)(double h, double z);
+typedef void (*BayesLogit_rpg_hybrid_fill_t)(int n, const double *h,
+                                             const double *z, double *out);
+
+static inline BayesLogit_rpg_gamma_t BayesLogit_rpg_gamma(void)
+{
+    return (BayesLogit_rpg_gamma_t)
+        R_GetCCallable("BayesLogit", "rpg_gamma");
+}
+
+static inline BayesLogit_rpg_gamma_fill_t BayesLogit_rpg_gamma_fill(void)
+{
+    return (BayesLogit_rpg_gamma_fill_t)
+        R_GetCCallable("BayesLogit", "rpg_gamma_fill");
+}
+
+static inline BayesLogit_rpg_devroye_t BayesLogit_rpg_devroye(void)
+{
+    return (BayesLogit_rpg_devroye_t)
+        R_GetCCallable("BayesLogit", "rpg_devroye");
+}
+
+static inline BayesLogit_rpg_devroye_fill_t BayesLogit_rpg_devroye_fill(void)
+{
+    return (BayesLogit_rpg_devroye_fill_t)
+        R_GetCCallable("BayesLogit", "rpg_devroye_fill");
+}
+
+static inline BayesLogit_rpg_sp_t BayesLogit_rpg_sp(void)
+{
+    return (BayesLogit_rpg_sp_t)
+        R_GetCCallable("BayesLogit", "rpg_sp");
+}
+
+static inline BayesLogit_rpg_sp_fill_t BayesLogit_rpg_sp_fill(void)
+{
+    return (BayesLogit_rpg_sp_fill_t)
+        R_GetCCallable("BayesLogit", "rpg_sp_fill");
+}
+
+static inline BayesLogit_rpg_hybrid_t BayesLogit_rpg_hybrid(void)
+{
+    return (BayesLogit_rpg_hybrid_t)
+        R_GetCCallable("BayesLogit", "rpg_hybrid");
+}
+
+static inline BayesLogit_rpg_hybrid_fill_t BayesLogit_rpg_hybrid_fill(void)
+{
+    return (BayesLogit_rpg_hybrid_fill_t)
+        R_GetCCallable("BayesLogit", "rpg_hybrid_fill");
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -32,6 +32,19 @@ extern void rpg_gamma(void *, void *, void *, void *, void *);
 extern void rpg_hybrid(void *, void *, void *, void *);
 extern void rpg_sp(void *, void *, void *, void *, void*);
 
+extern double BayesLogit_rpg_gamma(double, double, int);
+extern void BayesLogit_rpg_gamma_fill(int, const double *, const double *,
+                                      int, double *);
+extern double BayesLogit_rpg_devroye(int, double);
+extern void BayesLogit_rpg_devroye_fill(int, const int *, const double *,
+                                        double *);
+extern double BayesLogit_rpg_sp(double, double, int *);
+extern void BayesLogit_rpg_sp_fill(int, const double *, const double *,
+                                   double *, int *);
+extern double BayesLogit_rpg_hybrid(double, double);
+extern void BayesLogit_rpg_hybrid_fill(int, const double *, const double *,
+                                       double *);
+
 /* table of C calls */
 
 /* NB. The Makevars of 0.6 release exclude AR1.o and DynExpFamMH.o
@@ -54,4 +67,21 @@ void R_init_BayesLogit(DllInfo *dll)
 {
     R_registerRoutines(dll, cMethods, NULL, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
+
+    R_RegisterCCallable("BayesLogit", "rpg_gamma",
+                        (DL_FUNC) &BayesLogit_rpg_gamma);
+    R_RegisterCCallable("BayesLogit", "rpg_gamma_fill",
+                        (DL_FUNC) &BayesLogit_rpg_gamma_fill);
+    R_RegisterCCallable("BayesLogit", "rpg_devroye",
+                        (DL_FUNC) &BayesLogit_rpg_devroye);
+    R_RegisterCCallable("BayesLogit", "rpg_devroye_fill",
+                        (DL_FUNC) &BayesLogit_rpg_devroye_fill);
+    R_RegisterCCallable("BayesLogit", "rpg_sp",
+                        (DL_FUNC) &BayesLogit_rpg_sp);
+    R_RegisterCCallable("BayesLogit", "rpg_sp_fill",
+                        (DL_FUNC) &BayesLogit_rpg_sp_fill);
+    R_RegisterCCallable("BayesLogit", "rpg_hybrid",
+                        (DL_FUNC) &BayesLogit_rpg_hybrid);
+    R_RegisterCCallable("BayesLogit", "rpg_hybrid_fill",
+                        (DL_FUNC) &BayesLogit_rpg_hybrid_fill);
 }

--- a/src/polyagamma_wrapper.cpp
+++ b/src/polyagamma_wrapper.cpp
@@ -25,6 +25,128 @@
 #include "PolyaGammaApproxSP.h"
 #include "simple_RNG_wrapper.h"
 
+double BayesLogit_rpg_gamma(double h, double z, int trunc)
+{
+    PolyaGamma pg(trunc);
+    return h != 0.0 ? pg.draw_sum_of_gammas(h, z) : 0.0;
+}
+
+void BayesLogit_rpg_gamma_fill(int num, const double *h, const double *z,
+                               int trunc, double *out)
+{
+    PolyaGamma pg(trunc);
+
+    for(int i=0; i < num; ++i){
+#ifdef USE_R
+        if (i % 1000 == 0) R_CheckUserInterrupt();
+#endif
+        out[i] = h[i] != 0.0 ? pg.draw_sum_of_gammas(h[i], z[i]) : 0.0;
+    }
+}
+
+double BayesLogit_rpg_devroye(int h, double z)
+{
+    PolyaGamma pg(1);
+    return h != 0 ? pg.draw(h, z) : 0.0;
+}
+
+void BayesLogit_rpg_devroye_fill(int num, const int *h, const double *z,
+                                 double *out)
+{
+    PolyaGamma pg(1);
+
+    for(int i=0; i < num; ++i)
+        out[i] = h[i] != 0 ? pg.draw(h[i], z[i]) : 0.0;
+}
+
+double BayesLogit_rpg_sp(double h, double z, int *iter)
+{
+    double out = 0.0;
+    PolyaGammaApproxSP pg;
+
+    if (h != 0.0)
+        *iter = pg.draw(out, h, z);
+    else
+        *iter = 0;
+
+    return out;
+}
+
+void BayesLogit_rpg_sp_fill(int num, const double *h, const double *z,
+                            double *out, int *iter)
+{
+    PolyaGammaApproxSP pg;
+
+    for(int i=0; i < num; ++i){
+        if (h[i] != 0.0)
+            iter[i] = pg.draw(out[i], h[i], z[i]);
+        else {
+            out[i] = 0.0;
+            iter[i] = 0;
+        }
+    }
+}
+
+double BayesLogit_rpg_hybrid(double h, double z)
+{
+    PolyaGamma dv(1000);
+    PolyaGammaApproxSP sp;
+
+    if (h > 170) {
+        double m = dv.pg_m1(h, z);
+        double v = dv.pg_m2(h, z) - m*m;
+        return norm(m, sqrt(v));
+    }
+    else if (h > 13) {
+        double out = 0.0;
+        sp.draw(out, h, z);
+        return out;
+    }
+    else if (h == 1 || h == 2) {
+        return dv.draw((int)h, z);
+    }
+    // Need to review "alt" sampler.
+    // else if (h > 1) {
+    //     return alt.draw(h, z);
+    // }
+    else if (h > 0) {
+        return dv.draw_sum_of_gammas(h, z);
+    }
+
+    return 0.0;
+}
+
+void BayesLogit_rpg_hybrid_fill(int num, const double *h, const double *z,
+                                double *out)
+{
+    PolyaGamma dv(1000);
+    PolyaGammaApproxSP sp;
+
+    for(int i=0; i < num; ++i){
+        double b = h[i];
+        if (b > 170) {
+            double m = dv.pg_m1(b, z[i]);
+            double v = dv.pg_m2(b, z[i]) - m*m;
+            out[i] = norm(m, sqrt(v));
+        }
+        else if (b > 13) {
+            sp.draw(out[i], b, z[i]);
+        }
+        else if (b == 1 || b == 2) {
+            out[i] = dv.draw((int)b, z[i]);
+        }
+        // Need to review "alt" sampler.
+        // else if (b > 1) {
+        //     out[i] = alt.draw(b, z[i]);
+        // }
+        else if (b > 0) {
+            out[i] = dv.draw_sum_of_gammas(b, z[i]);
+        }
+        else {
+            out[i] = 0.0;
+        }
+    }
+}
 
 void rpg_gamma(double *x, double *n, double *z, int *num, int *trunc)
 {

--- a/src/polyagamma_wrapper.h
+++ b/src/polyagamma_wrapper.h
@@ -31,6 +31,21 @@ extern void rpg_alt(double *x, double *h, double *z, int* num);
 extern void rpg_sp(double *x, double *h, double *z, int* num, int *iter);
 extern void rpg_hybrid(double *x, double *h, double *z, int* num);
 
+extern double BayesLogit_rpg_gamma(double h, double z, int trunc);
+extern void BayesLogit_rpg_gamma_fill(int num, const double *h,
+                                      const double *z, int trunc,
+                                      double *out);
+extern double BayesLogit_rpg_devroye(int h, double z);
+extern void BayesLogit_rpg_devroye_fill(int num, const int *h,
+                                        const double *z, double *out);
+extern double BayesLogit_rpg_sp(double h, double z, int *iter);
+extern void BayesLogit_rpg_sp_fill(int num, const double *h,
+                                   const double *z, double *out,
+                                   int *iter);
+extern double BayesLogit_rpg_hybrid(double h, double z);
+extern void BayesLogit_rpg_hybrid_fill(int num, const double *h,
+                                       const double *z, double *out);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
 Hi Jesse,

First, thank you for making BayesLogit available and for your extremely impactful work on Polya-Gamma latent variables. That work has had a wide reach in my area of environmental and spatial modeling, and BayesLogit has been very useful.

This PR adds a C-callable API for BayesLogit Polya-Gamma RNGs using R_RegisterCCallable() and an installed inst/include/BayesLogit.h header.

The motivation is to let downstream R packages call BayesLogit’s Polya-Gamma RNGs from C/C++ without vendoring the source code. The patch does not change existing R functions or existing .C() entry points; it only adds native functions for package-to-package use.

The new functions follow R’s native RNG convention: they use R’s RNG but do not call GetRNGstate() or PutRNGstate(); callers must own R’s RNG state.

Added scalar and fill APIs for:
  - rpg_devroye
  - rpg_hybrid
  - rpg_gamma
  - rpg_sp

I tested the patch by building a small downstream package using LinkingTo: BayesLogit. The native calls matched BayesLogit’s R wrappers under matched seeds for Devroye, hybrid, gamma, and saddlepoint samplers.

I also ran R CMD check --as-cran before and after the patch; the patch did not introduce any new errors or warnings in my environment.

I’m happy to revise the API names or scope if you’d prefer a different convention.
